### PR TITLE
Remove checks option

### DIFF
--- a/packages/vc-http-api-test-server/__tests__/verifyCredential.spec.js
+++ b/packages/vc-http-api-test-server/__tests__/verifyCredential.spec.js
@@ -21,7 +21,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -32,7 +31,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 body.verifiableCredential.proof.jws += 'bar';
@@ -46,7 +44,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 delete body.verifiableCredential.proof.created;
@@ -60,7 +57,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: {...verifiableCredentials[0].data},
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 body.verifiableCredential.proof.proofPurpose = 'bar';
@@ -74,7 +70,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 body.verifiableCredential.newProp = 'foo';
@@ -88,7 +83,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 delete body.verifiableCredential.issuer;
@@ -102,7 +96,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 body.verifiableCredential.issuer = 'bar';
@@ -116,7 +109,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 body.verifiableCredential.proof.newProp = 'bar';
@@ -130,7 +122,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 delete body.verifiableCredential.proof.proofPurpose;
@@ -144,7 +135,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 body.verifiableCredential.proof.created += 'bar';
@@ -158,7 +148,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: verifiableCredentials[0].data,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -173,7 +162,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                     verifiableCredential: null,
                     options: {
-                        checks: ['proof'],
                     },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -191,7 +179,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 const body = {
                 verifiableCredential: vc,
                 options: {
-                    checks: ['proof'],
                 },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -218,7 +205,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                                         const body = {
                                             verifiableCredential,
                                             options: {
-                                                checks: ['proof', 'credentialStatus'],
                                             },
                                         };
                                         const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -231,7 +217,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                                         const body = {
                                             verifiableCredential,
                                             options: {
-                                                checks: ['proof', 'credentialStatus'],
                                             },
                                         };
                                         const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -261,7 +246,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                     const body = {
                     verifiableCredential: utilities.cloneObj(verifiableCredential.data),
                     options: {
-                        checks: ['proof'],
                     },
                     };
                     const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -272,7 +256,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                     const body = {
                     verifiableCredential: utilities.cloneObj(verifiableCredential.data),
                     options: {
-                        checks: ['proof'],
                     },
                     };
                     if (body.verifiableCredential.proof.jws) {
@@ -288,7 +271,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                     const body = {
                     verifiableCredential: utilities.cloneObj(verifiableCredential.data),
                     options: {
-                        checks: ['proof'],
                     },
                     };
                     body.verifiableCredential.badPropTest = "bad";
@@ -299,7 +281,6 @@ if (suiteConfig.verifyCredentialConfiguration) {
                     const body = {
                     verifiableCredential: utilities.cloneObj(verifiableCredential.data),
                     options: {
-                        checks: ['proof'],
                     },
                     };
                     // Assumes all interop test fixtures have a credential.credentialSubject property

--- a/packages/vc-http-api-test-server/__tests__/verifyPresentation.spec.js
+++ b/packages/vc-http-api-test-server/__tests__/verifyPresentation.spec.js
@@ -39,7 +39,6 @@ describe('Verify Presentation API', () => {
               options: {
                 challenge: vp.proof.challenge,
                 domain: vp.proof.domain,
-                checks: ['proof'],
               },
             };
             const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -69,7 +68,6 @@ describe('Verify Presentation API', () => {
               options: {
                 challenge: vp.proof.challenge,
                 domain: vp.proof.domain,
-                checks: ['proof'],
               },
             };
             const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -89,7 +87,6 @@ describe('Verify Presentation API', () => {
           options: {
             challenge: verifiablePresentations[0].proof.challenge,
             domain: verifiablePresentations[0].proof.domain,
-            checks: ['proof'],
           },
         };
         const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -106,7 +103,6 @@ describe('Verify Presentation API', () => {
           options: {
             challenge: verifiablePresentations[0].proof.challenge,
             domain: verifiablePresentations[0].proof.domain,
-            checks: ['proof'],
           },
         };
         const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -127,7 +123,6 @@ describe('Verify Presentation API', () => {
           options: {
             challenge: verifiablePresentations[0].proof.challenge,
             domain: verifiablePresentations[0].proof.domain,
-            checks: ['proof'],
           },
         };
         const res = await httpClient.postJson(verifierEndpoint, body, {});


### PR DESCRIPTION
As suggested in #8, remove use of the (unspecified) `checks` verification option.

With this change, I think it is expected that implementations check a credential/presentation's proof in all cases (as previously the "proof" check was passed in all cases), and check `credentialStatus` for verifiable credentials when the `credentialStatus property is present (Previously the "credentialStatus" check was passed for verifiable credentials [case-14.json](https://github.com/w3c-ccg/vc-api-test-suite/blob/a74c63d2d015efcb1c5d22a5d283536026faf5ec/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-14.json) and [case-15.json](https://github.com/w3c-ccg/vc-api-test-suite/blob/main/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-15.json)).

`checks` is still expected to be in the responses (`VerificationResult`) as before.

Related discussion of what should be checked during verification: https://github.com/w3c-ccg/vc-api/issues/59.