### PR TITLE
Regenerate VCs for updated revocation list

### DIFF
--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-14.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-14.json
@@ -18,7 +18,7 @@
       "id": "https://issuer.oidp.uscis.gov/credentials/status/3#94567",
       "type": "RevocationList2020Status",
       "revocationListIndex": "0",
-      "revocationListCredential": "https://w3c-ccg.github.io/vc-http-api/fixtures/revocationList.json"
+      "revocationListCredential": "https://w3c-ccg.github.io/vc-api/fixtures/revocationList.json"
     },
     "credentialSubject": {
       "id": "did:example:b34ca6cd37bbf23",
@@ -37,12 +37,12 @@
       "birthCountry": "Bahamas",
       "birthDate": "1958-07-17"
     },
-    "issuer": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3",
+    "issuer": "did:key:z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2021-02-16T04:32:29Z",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nFXiF3D2p-Pt6K75si3Gg8ZOP7rvbEYSP3kkXUj-d5TbrGWTfxjE6u4rb89mSRvmkxsldZH1RSdxLbAM-aP6Dw",
+      "created": "2021-10-29T19:12:37Z",
+      "jws": "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..CVymCwykmbH335C2Be4SyqFb7ANeIK9DktUd5yMHvGUKPm6TfRZKITz7J2kcQe14b99yrIjrTGTTxAJhK6bzBw",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3#z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+      "verificationMethod": "did:key:z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5#z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5"
     }
 }

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-15.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-15.json
@@ -18,7 +18,7 @@
     "id": "https://issuer.oidp.uscis.gov/credentials/status/3#94567",
     "type": "RevocationList2020Status",
     "revocationListIndex": "1",
-    "revocationListCredential": "https://w3c-ccg.github.io/vc-http-api/fixtures/revocationList.json"
+    "revocationListCredential": "https://w3c-ccg.github.io/vc-api/fixtures/revocationList.json"
   },
   "credentialSubject": {
     "id": "did:example:b34ca6cd37bbf23",
@@ -37,12 +37,12 @@
     "birthCountry": "Bahamas",
     "birthDate": "1958-07-17"
   },
-  "issuer": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3",
+  "issuer": "did:key:z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5",
   "proof": {
     "type": "Ed25519Signature2018",
-    "created": "2021-02-18T04:19:23Z",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tM_94zQxF5LwVqaW1Q4iGnkEDyn9Mbg7A6l3d1sVd9-Yt6AOVvAILqYKWuGiXIOy64Eudw_y0UMJ4I0XpEeUAw",
+    "created": "2021-10-29T19:12:49Z",
+    "jws": "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..bY6l_7AEvsRxX7fmwudwtt6dczEmsRbiNgQv_CYamX7AaA0SinvWTTM2tWUAzzlNEshTCsJY0cbWGKWaHjtsAQ",
     "proofPurpose": "assertionMethod",
-    "verificationMethod": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3#z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+    "verificationMethod": "did:key:z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5#z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5"
   }
 }


### PR DESCRIPTION
Reissue the verifiable credential test vectors that use a `RevocationList2020Status`, to use the revocation list credential that is renamed and reissued in https://github.com/w3c-ccg/vc-api/pull/242.