### PR TITLE
Reframe case-29 and case-30 for updated context

### DIFF
--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-29.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-29.json
@@ -19,7 +19,7 @@
     "modeOfTransport": "Truck",
     "portOfEntry": {
       "type": "ShippingStop",
-      "shippingStopAddress": {
+      "https://schema.org/PostalAddress": {
         "type": "PostalAddress",
         "organizationName": "Donnelly, Schulist and Schneider",
         "streetAddress": "17034 Russ Mission",
@@ -28,7 +28,7 @@
         "postalCode": "13098-9352",
         "addressCountry": "Gibraltar"
       },
-      "carrier": {
+      "https://schema.org/Organizationn": {
         "type": "Organization",
         "name": "Koch and Sons",
         "description": "Multi-layered global productivity",

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-30.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-30.json
@@ -20,7 +20,7 @@
     "finalModeOfTransport": "Air",
     "finalPortOfEntry": {
       "type": "ShippingStop",
-      "shippingStopAddress": {
+      "https://schema.org/PostalAddress": {
         "type": "PostalAddress",
         "organizationName": "Fritsch and Sons",
         "streetAddress": "9588 Lizzie Wall",
@@ -29,7 +29,7 @@
         "postalCode": "50233",
         "addressCountry": "Colombia"
       },
-      "carrier": {
+      "https://schema.org/Organizationn": {
         "type": "Organization",
         "name": "Wunsch, Nitzsche and Schaden",
         "description": "Progressive optimal migration",


### PR DESCRIPTION
Fix #16. These changes should make these two test vector verifiable credentials verify using the current Traceability context file.